### PR TITLE
Fix octal notation for Python 3

### DIFF
--- a/service.py
+++ b/service.py
@@ -88,7 +88,7 @@ def Download(id,url,format,stack=False):
     zip = os.path.join( __temp__, "OpenSubtitles.zip")
     f = urllib.urlopen(url)
     if not os.path.exists( __temp__ ):
-        os.mkdir( __temp__, mode=0775 )
+        os.mkdir( __temp__, mode=0o775 )
     with open(zip, "wb") as subFile:
       subFile.write(f.read())
     subFile.close()


### PR DESCRIPTION
Accotding to pep-3127, the gramar for an octal number is `"0" ("o" |
"O") octdigit+`

https://www.python.org/dev/peps/pep-3127/

This fixes:

```
2020-12-28 20:11:38.452 T:102161   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'SyntaxError'>
                                                   Error Contents: invalid token (service.py, line 91)
                                                     File "/home/romain/.kodi/addons/service.subtitles.opensubtitles/service.py", line 91
                                                       os.mkdir( __temp__, mode=0775 )
                                                                                   ^
                                                   SyntaxError: invalid token
                                                   -->End of Python script error report<--

2020-12-28 20:11:38.476 T:102161    INFO <general>: Python interpreter stopped
2020-12-28 20:11:38.487 T:101946   ERROR <general>: GetDirectory - Error getting plugin://service.subtitles.opensubtitles_by_opensubtitles/?action=search&languages=English%2cFrench&preferredlanguage=Undetermined
```